### PR TITLE
fix(nvim/mason): resolve lspconfig mapping API usage

### DIFF
--- a/.config/nvim/lua/plugins/mason-workaround.lua
+++ b/.config/nvim/lua/plugins/mason-workaround.lua
@@ -1,0 +1,9 @@
+-- The mason-lspconfig.mappings.server module was never really public, the recommended stable interface would be:
+-- require("mason-lspconfig").get_mappings().lspconfig_to_package
+-- -- or alternatively (although not technically a public API)
+-- require("mason-lspconfig.mappings").get_mason_map().lspconfig_to_package
+-- solution: https://github.com/LazyVim/LazyVim/issues/6039
+return {
+  { "mason-org/mason.nvim", version = "^1.0.0" },
+  { "mason-org/mason-lspconfig.nvim", version = "^1.0.0" },
+}


### PR DESCRIPTION
Add mason-workaround.lua to properly handle mason-lspconfig mappings API. Replaces non-public 'mason-lspconfig.mappings.server' usage with stable:
1. require("mason-lspconfig").get_mappings().lspconfig_to_package
2. require("mason-lspconfig.mappings").get_mason_map().lspconfig_to_package

References: https://github.com/LazyVim/LazyVim/issues/6039 
Close #10